### PR TITLE
Use `WP_DEBUG_DISPLAY` instead of `WP_DEBUG` for showing stats. Fix #21

### DIFF
--- a/config.php
+++ b/config.php
@@ -113,7 +113,7 @@ $this->ICCProfile = '';	// Colour profile OutputIntent
 // Must be CMYK for PDFX, or appropriate type for PDFA(RGB or CMYK)
 
 // DEBUGGING & DEVELOPERS
-$this->showStats = (defined('WP_DEBUG') && WP_DEBUG === true) ? true : false;;
+$this->showStats = (defined('WP_DEBUG_DISPLAY') && WP_DEBUG_DISPLAY === true) ? true : false;;
 $this->debug = (defined('WP_DEBUG') && WP_DEBUG === true) ? true : false;;
 $this->debugfonts = false;; // Checks and reports on errors when parsing TTF files - adds significantly to processing time
 $this->showImageErrors = false;


### PR DESCRIPTION
See https://codex.wordpress.org/Debugging_in_WordPress#WP_DEBUG_DISPLAY